### PR TITLE
README: fixup: case sensitivity in second license-related link

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ If you prefer to stay in software land, head out to [the software issues](https:
 
 See [License](LICENSE).
 We'll gladly accept contributions via Pull Requests.  Contributions are
-accepted under the same [License](License) of the project, as captured in
+accepted under the same [License](LICENSE) of the project, as captured in
 [github's terms of
 service](https://docs.github.com/en/github/site-policy/github-terms-of-service#6-contributions-under-repository-license).
 


### PR DESCRIPTION
The hyperlink that appears earlier in the paragraph works fine; the one adjusted here may result in an HTTP 404 because the filename is `LICENSE` (case-sensitive).